### PR TITLE
With logging - D0 to set LoRa address

### DIFF
--- a/Range_Testing/Range_Test_Hub/LoRaRangeTestHub/src/LoRaRangeTestHub.ino
+++ b/Range_Testing/Range_Test_Hub/LoRaRangeTestHub/src/LoRaRangeTestHub.ino
@@ -38,6 +38,9 @@ SYSTEM_THREAD(ENABLED);
 #define VERSION 1.00
 #define STATION_NUM 1 // housekeeping; not used ini the code
 
+const int DEBUG_LED_PIN = D7;
+const int LORA_ADDRESS_PIN = D0;
+
 String NODATA = "NODATA";
 tpp_LoRa LoRa;
 
@@ -55,7 +58,9 @@ void logToParticle(String message, String deviceNum, String payload, String SNRh
 
 void setup() {
 
-    pinMode(D7, OUTPUT);
+    pinMode(DEBUG_LED_PIN, OUTPUT); // control the onboard LED
+    pinMode(LORA_ADDRESS_PIN, INPUT_PULLUP); // used to set LoRa address on boot
+
     digitalWrite(D7, HIGH);
     Serial.begin(9600); // the USB serial port 
     Serial1.begin(38400); // (115200);  // the LoRa device
@@ -63,7 +68,13 @@ void setup() {
     waitUntil(Particle.connected);  // wait for the cloud to connect
     Serial.println("Hub version: " + String(VERSION));
 
-    if (LoRa.initDevice(TPP_LORA_HUB_ADDRESS) != 0) {  // initialize the LoRa device 
+    int addressForLoRa = TPP_LORA_HUB_ADDRESS;
+    int setAddressForHub = digitalRead(LORA_ADDRESS_PIN);
+    if (setAddressForHub == LOW) {
+        addressForLoRa = (rand() % 10) + 1;  // D0 is low, so set the address to 1
+    } 
+
+    if (LoRa.initDevice(addressForLoRa) != 0) {  // initialize the LoRa device 
         Serial.println("Error initializing LoRa device");
         while(1) {blinkTimes(50);};
         return;
@@ -79,7 +90,7 @@ void setup() {
     Serial.println("Hub ready for testing ...");
     Serial.print("waiting for data ...\n");
 
-    digitalWrite(D7, LOW);
+    digitalWrite(DEBUG_LED_PIN, LOW);
 
 } // end of setup()
 
@@ -102,7 +113,7 @@ void loop() {
             String logMessage = "";
             String messageSent = "";
             String deviceNum = LoRa.deviceNum;
-            digitalWrite(D7, HIGH);
+            digitalWrite(DEBUG_LED_PIN, HIGH);
             Serial.println("payload: " + LoRa.payload);
 
             if(LoRa.payload.indexOf("HELLO") >= 0) { // will be -1 if "HELLO" not in the string
@@ -131,7 +142,7 @@ void loop() {
             Serial.println("sent message: " + messageSent);
             logToParticle(logMessage, LoRa.deviceNum, LoRa.payload, LoRa.SNR, LoRa.RSSI);
 
-            digitalWrite(D7, LOW);
+            digitalWrite(DEBUG_LED_PIN, LOW);
             Serial.println("Waiting for messages");
 
             break;
@@ -145,9 +156,9 @@ void blinkTimes(int number) {
 
 void blinkTimes(int number, int delayTimeMS) {
     for(int i = 0; i < number; i++) {
-        digitalWrite(D7, HIGH);
+        digitalWrite(DEBUG_LED_PIN, HIGH);
         delay(delayTimeMS);
-        digitalWrite(D7, LOW);
+        digitalWrite(DEBUG_LED_PIN, LOW);
         delay(delayTimeMS);
     }
     return;

--- a/Range_Testing/Range_Test_Hub/LoRaRangeTestHub/src/LoRa_common/tpp_LoRa.h
+++ b/Range_Testing/Range_Test_Hub/LoRaRangeTestHub/src/LoRa_common/tpp_LoRa.h
@@ -22,11 +22,11 @@
 
 #define LoRaNETWORK_NUM 18
 
-#define LoRaBANDWIDTH 7         // default 7; 7:125kHz, 8:250kHz, 9:500kHz   lower is better for range but requires better
-                                // frequency stability between the two devices
-
 #define LoRaSPREADING_FACTOR 9  // default 9;  7 - 11  larger is better for range but slower
                                 // SF7 - SF9 at 125kHz, SF7 - SF10 at 250kHz, and SF7 - SF11 at 500kHz
+
+#define LoRaBANDWIDTH 7         // default 7; 7:125kHz, 8:250kHz, 9:500kHz   lower is better for range but requires better
+                                // frequency stability between the two devices
 
 #define LoRaCODING_RATE 1       // default 1; 1 is faster; [1: 4/5, 2: 4/6, 3: 4/7, 4: 4/8] This can result in
                                 // small signal gains at the limit of reception, but more symbols are sent for each character.

--- a/Range_Testing/Range_Test_Hub/LoRaRangeTestHub/src/LoRa_common/tpp_LoRa.h
+++ b/Range_Testing/Range_Test_Hub/LoRaRangeTestHub/src/LoRa_common/tpp_LoRa.h
@@ -22,16 +22,16 @@
 
 #define LoRaNETWORK_NUM 18
 
-#define LoRaBANDWIDTH 9         // default 7; 7:125kHz, 8:250kHz, 9:500kHz   lower is better for range but requires better
+#define LoRaBANDWIDTH 7         // default 7; 7:125kHz, 8:250kHz, 9:500kHz   lower is better for range but requires better
                                 // frequency stability between the two devices
 
-#define LoRaSPREADING_FACTOR 11  // default 9;  7 - 11  larger is better for range but slower
+#define LoRaSPREADING_FACTOR 9  // default 9;  7 - 11  larger is better for range but slower
                                 // SF7 - SF9 at 125kHz, SF7 - SF10 at 250kHz, and SF7 - SF11 at 500kHz
 
 #define LoRaCODING_RATE 1       // default 1; 1 is faster; [1: 4/5, 2: 4/6, 3: 4/7, 4: 4/8] This can result in
                                 // small signal gains at the limit of reception, but more symbols are sent for each character.
 
-#define LoRaPREAMBLE 24         // 12 max unless network number is 18; 
+#define LoRaPREAMBLE 12         // 12 max unless network number is 18; 
 
 // class for the LoRa module
 class tpp_LoRa


### PR DESCRIPTION
In the Hub, when booting the LoRa device parameters are set. By default the LoRa is given the device address of the Hub.

With this change, grounding D0 will cause the LoRa device to be initialized with a device address between 1 and 10 so that the LoRa module can be used in a sensor. This is useful for using the Hub to change LoRa settings for testing.

If D0 is left ungrounded or unconnected then there is no change to previous behavior and the LoRa module will be given the Hub address (as defined in the code with a constant).