### PR TITLE
Go Button is now an interrupt

### DIFF
--- a/Range_Testing/Range_Test_Sensor/RangeTestSensor/src/RangeTestSensor.ino
+++ b/Range_Testing/Range_Test_Sensor/RangeTestSensor/src/RangeTestSensor.ino
@@ -218,7 +218,7 @@ void loop() {
 
     // test for button to be pressed and no transmission in progress
     // this is where the power down code will go
-    //if(digitalRead(BUTTON_PIN) == LOW && !awaitingResponse) { // button press detected  // xxx
+    //if(digitalRead(BUTTON_PIN) == LOW && !awaitingResponse) { // button press detected  
     if(mgButtonPressed && !awaitingResponse) { // button press detected 
         digitalWrite(GRN_LED_PIN, HIGH);
         debugPrintln(F("\n\r--------------------")); 

--- a/Range_Testing/Range_Test_Sensor/RangeTestSensor/src/RangeTestSensor.ino
+++ b/Range_Testing/Range_Test_Sensor/RangeTestSensor/src/RangeTestSensor.ino
@@ -1,35 +1,48 @@
 /* 
- * Project RangeTestTx
+ * Project RangeTestSensor
  * Author: Bob Glicksman
  * Date: 4/25/24
  * 
  * Description:  This is code for a tester of LoRa signal range.  The tester is based upon
- *  a Particle Photon that is set up to not need Wifi (any Arduino can be used in its place).
+ *  a Particle Photon that is set up to not need Wifi (an ATmega328 can be used in its place).
  *  In addition to the Photon, a N.O. pushbutton switch is connected to ground at one end
- *  and Photon pin D0 on the other.  The LoRa module (RYLR998) is connected as follows:
+ *  and Photon pin D0 on the other.  On the ATMega a N.O. pushbutton is connected to Vcc at one
+ *  end and pin D2 on the other.
+ 
+    The LoRa module (RYLR998) is connected as follows:
  *  * Vcc to Photon 3.3v
  *  * GND to Photon GND
- *  * Tx to Photon Rx (Serial1)
- *  * Rx to Photon Tx (Serial1)
+ *  * Tx to Photon Rx (Serial1) (Serial on ATmega)
+ *  * Rx to Photon Tx (Serial1) (Serial on ATmega) 
  *  * Reset is not connected
  * 
- * The testing concept is to produce a companion device - the "hub".  The hub uses its LoRa module
+ *  The testing concept is to produce a companion device - the "hub".  The hub uses its LoRa module
  *  to listen for a message from the tester.  When a message is received, the hub responds with a
  *  message of its own.  If the tester receives the response message, it is still in range of the
  *  hub.
  * 
- * The tester is assigned device number 0 and the hub is assigned device number 1.  The network
- *  number used for testing is 3 and the baud rate to/from the LoRa modem is 115200.  Otherwise,
- *  the default LoRa module values are used.  NOTE:  the tester code does not set up these
- *  values.  The LoRa modules are set up using a PC and an FTDI USB-serial board.
+ * The tester is assigned any device number and the hub is assigned device number 57248, as defined
+    in tpp_LoRa.h   (it can be any arbitrary number in the range  0 - 65535).  The network
+ *  number used for testing is 18 and the baud rate to/from the LoRa modem is 38400 to be 
+    compatible with the ATmega328.  Otherwise,
+ *  the default LoRa module values are used.  NOTE:  the sensor code does not set up these
+ *  values if run on an ATmega.  The LoRa modules can be set up using a PC and an FTDI USB-serial
+    board. If the LoRa module is already set to 38400 baud, then they can be further configured
+    by connecting one to a Particle Photon 2 sensor. LoRa modules can also be set up using 
+    the Particle Photon 2 hub. 
  * 
- * The software senses pressing of the pushbutton and sends a short message to a companion LoRa
+ *  The software senses the falling (P2) or rising (ATmega) signal from the pressing of 
+    the pushbutton and sends a short message to a companion LoRa
  *  module in the hub.  The message is also printed on the Photon's USB serial port for debugging
  *  purposes.  The unit then waits 3 seconds for a response.  If a response is received 
- *  (data received from the hub, beginning with +RCV), the D7 LED is flashed three times.  If no
- *  data is received from the hub (distance too far), the D7 LED is flashed once.
+ *  (data received from the hub, beginning with +RCV), the Green LED (onboard D7 of the Photon) 
+    is flashed three times.  If no
+ *  data is received from the hub, the Green LED (onboard D7 of the Photon) is flashed once.
  * 
- * version 1.0; 4/25/24
+ * version 2.0; 4/25/24
+
+    20241212 - version 2. works on Particle Photon 2 
+
  */
 
 #include "tpp_LoRaGlobals.h"
@@ -45,7 +58,7 @@
     // SerialLogHandler logHandler(LOG_LEVEL_INFO);
 #endif
 
-#define VERSION 1.00
+#define VERSION 2.00
 #define STATION_NUM 0 // housekeeping; not used ini the code
 
 #define THIS_LORA_SENSOR_ADDRESS 5 // the address of the sensor
@@ -82,6 +95,22 @@ void blinkLED(int ledpin, int number, int delayTimeMS) {
     return;
 } // end of blinkLED()
 
+// blinkLEDsOnBoot() blinks the LEDs to indicate the system is booting
+void blinkLEDsOnBoot() {
+    digitalWrite(GRN_LED_PIN, LOW);
+    digitalWrite(RED_LED_PIN, LOW);
+    delay(100);
+    for(int i = 0; i < 3; i++) {
+        digitalWrite(GRN_LED_PIN, HIGH);
+        digitalWrite(RED_LED_PIN, HIGH);
+        delay(150);
+        digitalWrite(GRN_LED_PIN, LOW);
+        digitalWrite(RED_LED_PIN, LOW);
+        delay(100);
+    }
+    return;
+}
+
 void ISR_buttonPressed() {
     mgButtonPressed = true;
 }
@@ -93,7 +122,7 @@ void setup() {
         attachInterrupt(BUTTON_PIN, ISR_buttonPressed, FALLING);
     #else
         pinMode(BUTTON_PIN, INPUT);
-        attachInterrupt(digitalPinToInterrupt(BUTTON_PIN), ISR_buttonPressed, FALLING)
+        attachInterrupt(digitalPinToInterrupt(BUTTON_PIN), ISR_buttonPressed, FALLING);
     #endif
 
     pinMode(GRN_LED_PIN, OUTPUT); 
@@ -164,6 +193,8 @@ void setup() {
 
         debugPrintln(F("Sensor ready for testing ...\n" ));   
         
+        blinkLEDsOnBoot();
+
         digitalWrite(GRN_LED_PIN, LOW);
         digitalWrite(RED_LED_PIN, LOW);
     }
@@ -217,7 +248,7 @@ void loop() {
                 mgpayload += mglastSNR;
                 break;
         }
-        LoRa.transmitMessage(TPP_LORA_HUB_ADDRESS, mgpayload); /// send the address as an int 
+        LoRa.transmitMessage(String(TPP_LORA_HUB_ADDRESS), mgpayload); /// send the address as an int 
         mgButtonPressed = false;
         awaitingResponse = true;  
         startTime = millis();

--- a/Range_Testing/Range_Test_Sensor/RangeTestSensor/src/tpp_LoRa.cpp
+++ b/Range_Testing/Range_Test_Sensor/RangeTestSensor/src/tpp_LoRa.cpp
@@ -255,7 +255,7 @@ int tpp_LoRa::sendCommand(const String& command) {
     mg_LoRaBusy = true;
 
     int retcode = 0;
-    unsigned int timeoutMS = 1000; // xxx
+    unsigned int timeoutMS = 1000; // xxx see below - do we still need this?
     receivedData = "";
 
     tempString = F("cmd: ");
@@ -264,7 +264,8 @@ int tpp_LoRa::sendCommand(const String& command) {
     LORA_SERIAL.println(command);
     
     // wait for data available, which should be +OK or +ERR
-    unsigned int starttimeMS = millis();  // xxx
+    unsigned int starttimeMS = millis();  // xxx do we still need this timeout now that we use the
+                                          // xxx timeout in the serial port? Is this a good safety?
     int dataAvailable = 0;
     debugPrint(F("waiting "));
     do {
@@ -274,7 +275,7 @@ int tpp_LoRa::sendCommand(const String& command) {
     } while ((dataAvailable == 0) && (millis() - starttimeMS < timeoutMS)) ;
     debugPrintNoHeader(F("\n"));
 
-    delay(100); // wait for the full response
+    delay(100); // wait for the full response  //xxx we might not need this any more
 
     // Get the response if there is one
     if(dataAvailable > 0) {

--- a/Range_Testing/Range_Test_Sensor/RangeTestSensor/src/tpp_LoRa.cpp
+++ b/Range_Testing/Range_Test_Sensor/RangeTestSensor/src/tpp_LoRa.cpp
@@ -3,11 +3,13 @@
     created by Bob Glicksman and Jim Schrempp 2024
     as part of Team Practical Projects (tpp)
 
+    20241212 - works on Particle Photon 2
+
 */
 
 #include "tpp_LoRa.h"
 
-#define TPP_LORA_DEBUG 1  // Do NOT enable this for ATmega328
+#define TPP_LORA_DEBUG 0  // Do NOT enable this for ATmega328
 
 bool mg_LoRaBusy = false;
 
@@ -223,12 +225,12 @@ int tpp_LoRa::wake(){
         return false;
     }
 
-    if(sendCommand("AT") != 0) {    // XXX what is the problem here???
+    if(sendCommand("AT") != 0) {    
         debugPrintln(F("error waking up LoRa"));
         return true;
     }
 
-    if(sendCommand(F("AT+MODE=0")) != 0) {    // XXX what is the problem here???
+    if(sendCommand(F("AT+MODE=0")) != 0) {    
         debugPrintln(F("error setting LoRa to mode 0"));
         return true;
     } else { 
@@ -301,7 +303,7 @@ int tpp_LoRa::sendCommand(const String& command) {
 // function to transmit a message to another LoRa device
 // returns 0 if successful, 1 if error, -1 if no response
 // prints message and result to the serial monitor
-int tpp_LoRa::transmitMessage(int devAddress, const String& message){
+int tpp_LoRa::transmitMessage(const String& devAddress, const String& message){
 
     if(wake() != 0) {
         return true;

--- a/Range_Testing/Range_Test_Sensor/RangeTestSensor/src/tpp_LoRa.h
+++ b/Range_Testing/Range_Test_Sensor/RangeTestSensor/src/tpp_LoRa.h
@@ -3,6 +3,8 @@
     created by Bob Glicksman and Jim Schrempp 2024
     as part of Team Practical Projects (tpp)
 
+    20241212 - version 2. works on Particle Photon 2
+
 */
 /*
     The block below was recommended by CoPilo. It has nothing to do with our libary.
@@ -16,7 +18,7 @@
 
 #include "tpp_LoRaGlobals.h"
 
-#define VERSION 1.00
+#define VERSION 2.00
 
 #define TPP_LORA_HUB_ADDRESS 57248   // arbitrary  0 - 65535
 // xxx make this an int and convert to string as needed
@@ -74,7 +76,7 @@ public:
     // function to transmit a message to another LoRa device
     // returns 0 if successful, 1 if error, -1 if no response
     // prints message and result to the serial monitor
-    int transmitMessage(int devAddress, const String& message);
+    int transmitMessage(const String& devAddress, const String& message);
     // xxx add number or retries and a string refernce for the response
 
     // function puts LoRa to sleep. LoRa will awaken when sent

--- a/Range_Testing/Range_Test_Sensor/RangeTestSensor/src/tpp_LoRa.h
+++ b/Range_Testing/Range_Test_Sensor/RangeTestSensor/src/tpp_LoRa.h
@@ -21,7 +21,6 @@
 #define VERSION 2.00
 
 #define TPP_LORA_HUB_ADDRESS 57248   // arbitrary  0 - 65535
-// xxx make this an int and convert to string as needed
 
 #define LoRa_NETWORK_ID 18
 
@@ -76,8 +75,11 @@ public:
     // function to transmit a message to another LoRa device
     // returns 0 if successful, 1 if error, -1 if no response
     // prints message and result to the serial monitor
+    // XXX NOTE: when I changed this to an int for the address, the ATmega328 code broke
+    // XXX so I changed it back to a string. I don't know why yet.
     int transmitMessage(const String& devAddress, const String& message);
     // xxx add number or retries and a string refernce for the response
+    // xxx we need to discuss this
 
     // function puts LoRa to sleep. LoRa will awaken when sent
     // a command.  Returns 0 if successful, 1 if error
@@ -88,7 +90,7 @@ public:
     // called implicitly by other methods when needed
     int wake();
     
-    // xxx review all these to see what we really need in ATmega and can these be ints instead of strings
+    // class variables
     int receivedMessageState = 0; // 0 = no message, 1 = message received, -1 = error
     String UID;
     String receivedData; // xxx why do we need a receive buffer? Reuse the LoRaStringBuffer

--- a/Range_Testing/Range_Test_Sensor/RangeTestSensor/src/tpp_LoRaGlobals.h
+++ b/Range_Testing/Range_Test_Sensor/RangeTestSensor/src/tpp_LoRaGlobals.h
@@ -1,3 +1,14 @@
+/*
+    tpp_LoRaGlobals.h
+
+    Include this in all modules of the LoRa sensor and hub
+
+    20241212 - works on Particle Photon 2
+    
+    (c) 2024 Bob Glicksmand and Jim Schrempp
+
+*/
+
 #ifndef tpp_LoRaGlobals_h 
 #define tpp_LoRaGlobals_h
 

--- a/arduinoSketchbook/RangeTestSensor/RangeTestSensor.ino
+++ b/arduinoSketchbook/RangeTestSensor/RangeTestSensor.ino
@@ -41,7 +41,7 @@
  * 
  * version 2.0; 4/25/24
 
-    20241212 - version 2. works on ATmega328 
+    20241212 - version 2. works on Particle Photon 2 Verified on ATMega328
 
  */
 
@@ -218,7 +218,7 @@ void loop() {
 
     // test for button to be pressed and no transmission in progress
     // this is where the power down code will go
-    //if(digitalRead(BUTTON_PIN) == LOW && !awaitingResponse) { // button press detected  // xxx
+    //if(digitalRead(BUTTON_PIN) == LOW && !awaitingResponse) { // button press detected  
     if(mgButtonPressed && !awaitingResponse) { // button press detected 
         digitalWrite(GRN_LED_PIN, HIGH);
         debugPrintln(F("\n\r--------------------")); 

--- a/arduinoSketchbook/RangeTestSensor/RangeTestSensor.ino
+++ b/arduinoSketchbook/RangeTestSensor/RangeTestSensor.ino
@@ -1,35 +1,48 @@
 /* 
- * Project RangeTestTx
+ * Project RangeTestSensor
  * Author: Bob Glicksman
  * Date: 4/25/24
  * 
  * Description:  This is code for a tester of LoRa signal range.  The tester is based upon
- *  a Particle Photon that is set up to not need Wifi (any Arduino can be used in its place).
+ *  a Particle Photon that is set up to not need Wifi (an ATmega328 can be used in its place).
  *  In addition to the Photon, a N.O. pushbutton switch is connected to ground at one end
- *  and Photon pin D0 on the other.  The LoRa module (RYLR998) is connected as follows:
+ *  and Photon pin D0 on the other.  On the ATMega a N.O. pushbutton is connected to Vcc at one
+ *  end and pin D2 on the other.
+ 
+    The LoRa module (RYLR998) is connected as follows:
  *  * Vcc to Photon 3.3v
  *  * GND to Photon GND
- *  * Tx to Photon Rx (Serial1)
- *  * Rx to Photon Tx (Serial1)
+ *  * Tx to Photon Rx (Serial1) (Serial on ATmega)
+ *  * Rx to Photon Tx (Serial1) (Serial on ATmega) 
  *  * Reset is not connected
  * 
- * The testing concept is to produce a companion device - the "hub".  The hub uses its LoRa module
+ *  The testing concept is to produce a companion device - the "hub".  The hub uses its LoRa module
  *  to listen for a message from the tester.  When a message is received, the hub responds with a
  *  message of its own.  If the tester receives the response message, it is still in range of the
  *  hub.
  * 
- * The tester is assigned device number 0 and the hub is assigned device number 1.  The network
- *  number used for testing is 3 and the baud rate to/from the LoRa modem is 115200.  Otherwise,
- *  the default LoRa module values are used.  NOTE:  the tester code does not set up these
- *  values.  The LoRa modules are set up using a PC and an FTDI USB-serial board.
+ * The tester is assigned any device number and the hub is assigned device number 57248, as defined
+    in tpp_LoRa.h   (it can be any arbitrary number in the range  0 - 65535).  The network
+ *  number used for testing is 18 and the baud rate to/from the LoRa modem is 38400 to be 
+    compatible with the ATmega328.  Otherwise,
+ *  the default LoRa module values are used.  NOTE:  the sensor code does not set up these
+ *  values if run on an ATmega.  The LoRa modules can be set up using a PC and an FTDI USB-serial
+    board. If the LoRa module is already set to 38400 baud, then they can be further configured
+    by connecting one to a Particle Photon 2 sensor. LoRa modules can also be set up using 
+    the Particle Photon 2 hub. 
  * 
- * The software senses pressing of the pushbutton and sends a short message to a companion LoRa
+ *  The software senses the falling (P2) or rising (ATmega) signal from the pressing of 
+    the pushbutton and sends a short message to a companion LoRa
  *  module in the hub.  The message is also printed on the Photon's USB serial port for debugging
  *  purposes.  The unit then waits 3 seconds for a response.  If a response is received 
- *  (data received from the hub, beginning with +RCV), the D7 LED is flashed three times.  If no
- *  data is received from the hub (distance too far), the D7 LED is flashed once.
+ *  (data received from the hub, beginning with +RCV), the Green LED (onboard D7 of the Photon) 
+    is flashed three times.  If no
+ *  data is received from the hub, the Green LED (onboard D7 of the Photon) is flashed once.
  * 
- * version 1.0; 4/25/24
+ * version 2.0; 4/25/24
+
+    20241212 - version 2. works on ATmega328 
+
  */
 
 #include "tpp_LoRaGlobals.h"
@@ -45,7 +58,7 @@
     // SerialLogHandler logHandler(LOG_LEVEL_INFO);
 #endif
 
-#define VERSION 1.00
+#define VERSION 2.00
 #define STATION_NUM 0 // housekeeping; not used ini the code
 
 #define THIS_LORA_SENSOR_ADDRESS 5 // the address of the sensor
@@ -57,8 +70,10 @@
 tpp_LoRa LoRa; // create an instance of the LoRa class
 
 // module global scope for mimimal string memboery allocation
-int mglastRSSI;
-int mglastSNR;
+int mglastRSSI = 0;
+int mglastSNR = 0;
+bool mgFatalError = false;
+volatile bool mgButtonPressed = false;  // set true in the ISR_buttonPressed() function
 String mgpayload;
 String mgTemp;
 
@@ -80,13 +95,36 @@ void blinkLED(int ledpin, int number, int delayTimeMS) {
     return;
 } // end of blinkLED()
 
+// blinkLEDsOnBoot() blinks the LEDs to indicate the system is booting
+void blinkLEDsOnBoot() {
+    digitalWrite(GRN_LED_PIN, LOW);
+    digitalWrite(RED_LED_PIN, LOW);
+    delay(100);
+    for(int i = 0; i < 3; i++) {
+        digitalWrite(GRN_LED_PIN, HIGH);
+        digitalWrite(RED_LED_PIN, HIGH);
+        delay(150);
+        digitalWrite(GRN_LED_PIN, LOW);
+        digitalWrite(RED_LED_PIN, LOW);
+        delay(100);
+    }
+    return;
+}
+
+void ISR_buttonPressed() {
+    mgButtonPressed = true;
+}
+
 void setup() {
 
-    if (PARTICLEPHOTON) {
+    #if PARTICLEPHOTON
         pinMode(BUTTON_PIN, INPUT_PULLUP);
-    } else {
+        attachInterrupt(BUTTON_PIN, ISR_buttonPressed, FALLING);
+    #else
         pinMode(BUTTON_PIN, INPUT);
-    }                                 
+        attachInterrupt(digitalPinToInterrupt(BUTTON_PIN), ISR_buttonPressed, FALLING);
+    #endif
+
     pinMode(GRN_LED_PIN, OUTPUT); 
     pinMode(RED_LED_PIN, OUTPUT); 
 
@@ -108,54 +146,59 @@ void setup() {
         if (PARTICLEPHOTON) {
             debugPrintln(F("error initializing LoRa device - Stopping"));
         }
-        while(1) {blinkLED(RED_LED_PIN, 500, 20);};
+        mgFatalError = true;
+        blinkLED(RED_LED_PIN, 20, 50);
     }
 
 
-    if (PARTICLEPHOTON) {
+    if (!mgFatalError && PARTICLEPHOTON) {
         if (LoRa.configDevice(THIS_LORA_SENSOR_ADDRESS) != 0) {  // initialize the LoRa device
-                debugPrintln(F("error configuring LoRa device - Stopping"));
-                debugPrintln(F("hint: did you set THIS_LORA_SENSOR_ADDRESS?"));
-            while(1) {blinkLED(RED_LED_PIN, 500, 50);};  //xxx quick flashes for error, then continue and let it power down if atmega
+            debugPrintln(F("error configuring LoRa device - Stopping"));
+            debugPrintln(F("hint: did you set THIS_LORA_SENSOR_ADDRESS?"));
+            mgFatalError = true;
+            blinkLED(RED_LED_PIN, 20, 50);
+        } else {
+            if (LoRa.readSettings() != 0) {  // read the settings from the LoRa device
+                debugPrintln(F("error reading LoRa settings - Stopping"));
+                mgFatalError = true;
+                blinkLED(RED_LED_PIN, 20, 75);      
+            }; 
 
-        }; 
-
-        if (LoRa.readSettings() != 0) {  // read the settings from the LoRa device
-            debugPrintln(F("error reading LoRa settings - Stopping"));
-            while(1) {blinkLED(RED_LED_PIN, 500, 75);};  //xxx quick flashes for error, then continue and let it power down if atmega
-            
-        }; 
-
-        mgTemp =  F("LoRa Network ID = ");
-        mgTemp += LoRa.LoRaNetworkID;
-        debugPrintln(mgTemp);
-        mgTemp =  F("LoRa UID = ");
-        mgTemp += LoRa.UID;
-        debugPrintln(mgTemp);
-        mgTemp =  F("LoRa device address = ");
-        mgTemp += LoRa.LoRaDeviceAddress;
-        debugPrintln(mgTemp);
-        mgTemp =  F("LoRa parameters = ");
-        mgTemp += LoRa.LoRaSpreadingFactor;
-        mgTemp += F(", ");
-        mgTemp += LoRa.LoRaBandwidth;
-        mgTemp += F(", ");
-        mgTemp += LoRa.LoRaCodingRate;
-        mgTemp += F(", ");
-        mgTemp += LoRa.LoRaPreamble;
-        debugPrintln(mgTemp);
-        mgTemp = F("LoRa CRFOP = ");
-        mgTemp += LoRa.LoRaCRFOP;
-        debugPrintln(mgTemp);
-
+            mgTemp =  F("LoRa Network ID = ");
+            mgTemp += LoRa.LoRaNetworkID;
+            debugPrintln(mgTemp);
+            mgTemp =  F("LoRa UID = ");
+            mgTemp += LoRa.UID;
+            debugPrintln(mgTemp);
+            mgTemp =  F("LoRa device address = ");
+            mgTemp += LoRa.LoRaDeviceAddress;
+            debugPrintln(mgTemp);
+            mgTemp =  F("LoRa parameters = ");
+            mgTemp += LoRa.LoRaSpreadingFactor;
+            mgTemp += F(", ");
+            mgTemp += LoRa.LoRaBandwidth;
+            mgTemp += F(", ");
+            mgTemp += LoRa.LoRaCodingRate;
+            mgTemp += F(", ");
+            mgTemp += LoRa.LoRaPreamble;
+            debugPrintln(mgTemp);
+            mgTemp = F("LoRa CRFOP = ");
+            mgTemp += LoRa.LoRaCRFOP;
+            debugPrintln(mgTemp);
+        }
     }
     
-    LoRa.sleep(); // put the LoRa module to sleep
+    if (!mgFatalError) {
+        LoRa.sleep(); // put the LoRa module to sleep
 
-    debugPrintln(F("Sensor ready for testing ...\n" ));   
+        debugPrintln(F("Sensor ready for testing ...\n" ));   
+        
+        blinkLEDsOnBoot();
+
+        digitalWrite(GRN_LED_PIN, LOW);
+        digitalWrite(RED_LED_PIN, LOW);
+    }
     
-    digitalWrite(GRN_LED_PIN, LOW);
-    digitalWrite(RED_LED_PIN, LOW);
 
 } // end of setup()
 
@@ -165,10 +208,18 @@ void loop() {
     static bool awaitingResponse = false; // when waiting for a response from the hub
     static unsigned long startTime = 0;
     static int msgNum = 0;
+    bool needToSleep = false;
+
+    // XXX if fatal error then power down the ATmega328
+    if (mgFatalError) {
+        delay(1000);
+        return;
+    }   
 
     // test for button to be pressed and no transmission in progress
     // this is where the power down code will go
-    if(digitalRead(BUTTON_PIN) == LOW && !awaitingResponse) { // button press detected  // xxx
+    //if(digitalRead(BUTTON_PIN) == LOW && !awaitingResponse) { // button press detected  // xxx
+    if(mgButtonPressed && !awaitingResponse) { // button press detected 
         digitalWrite(GRN_LED_PIN, HIGH);
         debugPrintln(F("\n\r--------------------")); 
         msgNum++;
@@ -198,7 +249,8 @@ void loop() {
                 break;
         }
         LoRa.transmitMessage(String(TPP_LORA_HUB_ADDRESS), mgpayload); /// send the address as an int 
-        awaitingResponse = true;
+        mgButtonPressed = false;
+        awaitingResponse = true;  
         startTime = millis();
         digitalWrite(GRN_LED_PIN, LOW);
     }
@@ -209,14 +261,16 @@ void loop() {
             awaitingResponse = false;  // timed out
             blinkLED(RED_LED_PIN, 1, 250);
             debugPrintln(F("timeout waiting for hub response"));
+            needToSleep = true;
         }
+
         LoRa.checkForReceivedMessage();
         switch (LoRa.receivedMessageState) {
             case -1: // error
                 awaitingResponse = false;  // error
                 blinkLED(RED_LED_PIN, 7, 250);
                 debugPrintln(F("error while waiting for response"));
-                LoRa.sleep();
+                needToSleep = true;
                 break;
             case 0: // no message
                 delay(5); // wait a little while before checking again
@@ -245,20 +299,17 @@ void loop() {
                         blinkLED(RED_LED_PIN, 5, 250);
                     }
                 } 
-                LoRa.sleep();
+                needToSleep = true;
                 break;
 
         } // end of switch(LoRa.receivedMessageState)
 
-
-
     } // end of if(awaitingResponse)
 
     // xxx this is where the power down code goes
-
-
-    //while(digitalRead(D0) == LOW); // wait for button to be released
-    //delay(1); // wait a little while before sampling the button again
+    if (needToSleep) {
+        LoRa.sleep(); // put the LoRa module to sleep
+    }
 
 } // end of loop()
 

--- a/arduinoSketchbook/RangeTestSensor/tpp_LoRa.cpp
+++ b/arduinoSketchbook/RangeTestSensor/tpp_LoRa.cpp
@@ -3,13 +3,13 @@
     created by Bob Glicksman and Jim Schrempp 2024
     as part of Team Practical Projects (tpp)
 
-    20241212 - works on ATmega328
+    20241212 - works on Particle Photon 2  Verified on ATMega328
 
 */
 
 #include "tpp_LoRa.h"
 
-#define TPP_LORA_DEBUG 0 // Do NOT enable this for ATmega328
+#define TPP_LORA_DEBUG 0  // Do NOT enable this for ATmega328
 
 bool mg_LoRaBusy = false;
 
@@ -255,7 +255,7 @@ int tpp_LoRa::sendCommand(const String& command) {
     mg_LoRaBusy = true;
 
     int retcode = 0;
-    unsigned int timeoutMS = 1000; // xxx
+    unsigned int timeoutMS = 1000; // xxx see below - do we still need this?
     receivedData = "";
 
     tempString = F("cmd: ");
@@ -264,7 +264,8 @@ int tpp_LoRa::sendCommand(const String& command) {
     LORA_SERIAL.println(command);
     
     // wait for data available, which should be +OK or +ERR
-    unsigned int starttimeMS = millis();  // xxx
+    unsigned int starttimeMS = millis();  // xxx do we still need this timeout now that we use the
+                                          // xxx timeout in the serial port? Is this a good safety?
     int dataAvailable = 0;
     debugPrint(F("waiting "));
     do {
@@ -274,7 +275,7 @@ int tpp_LoRa::sendCommand(const String& command) {
     } while ((dataAvailable == 0) && (millis() - starttimeMS < timeoutMS)) ;
     debugPrintNoHeader(F("\n"));
 
-    delay(100); // wait for the full response
+    delay(100); // wait for the full response  //xxx we might not need this any more
 
     // Get the response if there is one
     if(dataAvailable > 0) {

--- a/arduinoSketchbook/RangeTestSensor/tpp_LoRa.cpp
+++ b/arduinoSketchbook/RangeTestSensor/tpp_LoRa.cpp
@@ -3,11 +3,13 @@
     created by Bob Glicksman and Jim Schrempp 2024
     as part of Team Practical Projects (tpp)
 
+    20241212 - works on ATmega328
+
 */
 
 #include "tpp_LoRa.h"
 
-#define TPP_LORA_DEBUG 0  // Do NOT enable this for ATmega328
+#define TPP_LORA_DEBUG 0 // Do NOT enable this for ATmega328
 
 bool mg_LoRaBusy = false;
 
@@ -223,12 +225,12 @@ int tpp_LoRa::wake(){
         return false;
     }
 
-    if(sendCommand("AT") != 0) {    // XXX what is the problem here???
+    if(sendCommand("AT") != 0) {    
         debugPrintln(F("error waking up LoRa"));
         return true;
     }
 
-    if(sendCommand(F("AT+MODE=0")) != 0) {    // XXX what is the problem here???
+    if(sendCommand(F("AT+MODE=0")) != 0) {    
         debugPrintln(F("error setting LoRa to mode 0"));
         return true;
     } else { 

--- a/arduinoSketchbook/RangeTestSensor/tpp_LoRa.h
+++ b/arduinoSketchbook/RangeTestSensor/tpp_LoRa.h
@@ -3,7 +3,7 @@
     created by Bob Glicksman and Jim Schrempp 2024
     as part of Team Practical Projects (tpp)
 
-    20241212 - works on ATmega328
+    20241212 - version 2. works on Particle Photon 2  Verified on ATMega328
 
 */
 /*
@@ -11,7 +11,6 @@
     tpp_LoRa.h - Library for LoRa communication with the Things Plus Plus board.
     Created by Bennett Marsh, 2021.
     Released into the public domain.
-
 
 */
 #ifndef tpp_LoRa_h 
@@ -22,7 +21,6 @@
 #define VERSION 2.00
 
 #define TPP_LORA_HUB_ADDRESS 57248   // arbitrary  0 - 65535
-// xxx make this an int and convert to string as needed
 
 #define LoRa_NETWORK_ID 18
 
@@ -77,8 +75,11 @@ public:
     // function to transmit a message to another LoRa device
     // returns 0 if successful, 1 if error, -1 if no response
     // prints message and result to the serial monitor
+    // XXX NOTE: when I changed this to an int for the address, the ATmega328 code broke
+    // XXX so I changed it back to a string. I don't know why yet.
     int transmitMessage(const String& devAddress, const String& message);
     // xxx add number or retries and a string refernce for the response
+    // xxx we need to discuss this
 
     // function puts LoRa to sleep. LoRa will awaken when sent
     // a command.  Returns 0 if successful, 1 if error
@@ -89,7 +90,7 @@ public:
     // called implicitly by other methods when needed
     int wake();
     
-    // xxx review all these to see what we really need in ATmega and can these be ints instead of strings
+    // class variables
     int receivedMessageState = 0; // 0 = no message, 1 = message received, -1 = error
     String UID;
     String receivedData; // xxx why do we need a receive buffer? Reuse the LoRaStringBuffer

--- a/arduinoSketchbook/RangeTestSensor/tpp_LoRa.h
+++ b/arduinoSketchbook/RangeTestSensor/tpp_LoRa.h
@@ -3,6 +3,8 @@
     created by Bob Glicksman and Jim Schrempp 2024
     as part of Team Practical Projects (tpp)
 
+    20241212 - works on ATmega328
+
 */
 /*
     The block below was recommended by CoPilo. It has nothing to do with our libary.
@@ -10,13 +12,14 @@
     Created by Bennett Marsh, 2021.
     Released into the public domain.
 
+
 */
 #ifndef tpp_LoRa_h 
 #define tpp_LoRa_h
 
 #include "tpp_LoRaGlobals.h"
 
-#define VERSION 1.00
+#define VERSION 2.00
 
 #define TPP_LORA_HUB_ADDRESS 57248   // arbitrary  0 - 65535
 // xxx make this an int and convert to string as needed

--- a/arduinoSketchbook/RangeTestSensor/tpp_LoRaGlobals.h
+++ b/arduinoSketchbook/RangeTestSensor/tpp_LoRaGlobals.h
@@ -2,11 +2,13 @@
     tpp_LoRaGlobals.h
 
     Include this in all modules of the LoRa sensor and hub
+
+    20241212 - works on Particle Photon 2. Verified on ATMega328
     
     (c) 2024 Bob Glicksmand and Jim Schrempp
 
-    20241212 - works on ATmega328
 */
+
 #ifndef tpp_LoRaGlobals_h 
 #define tpp_LoRaGlobals_h
 

--- a/arduinoSketchbook/RangeTestSensor/tpp_LoRaGlobals.h
+++ b/arduinoSketchbook/RangeTestSensor/tpp_LoRaGlobals.h
@@ -1,3 +1,12 @@
+/*
+    tpp_LoRaGlobals.h
+
+    Include this in all modules of the LoRa sensor and hub
+    
+    (c) 2024 Bob Glicksmand and Jim Schrempp
+
+    20241212 - works on ATmega328
+*/
 #ifndef tpp_LoRaGlobals_h 
 #define tpp_LoRaGlobals_h
 


### PR DESCRIPTION
This completes most changes for the ATMega328 low memory mode. The identical code runs on a Photon 2 if you change the #define in the tpp_LoRaGlobals.h file. 

The go button is now an ISR. Rising on ATmega and Falling on P2.

To avoid confusion, a reboot now blinks both green and red LEDs on the ATMega three times.

Please search in each of the four files for "xxx". This will show you open questions and concerns.