### PR TITLE
ATmega runs 300 transactions

### DIFF
--- a/Range_Testing/Range_Test_Sensor/RangeTestSensor/src/RangeTestSensor.ino
+++ b/Range_Testing/Range_Test_Sensor/RangeTestSensor/src/RangeTestSensor.ino
@@ -42,6 +42,7 @@
  * version 2.0; 4/25/24
 
     20241212 - version 2. works on Particle Photon 2 
+    v 2.1 pulled all string searches out of if() clauses
 
  */
 
@@ -58,7 +59,7 @@
     // SerialLogHandler logHandler(LOG_LEVEL_INFO);
 #endif
 
-#define VERSION 2.00
+#define VERSION 2.10
 #define STATION_NUM 0 // housekeeping; not used ini the code
 
 #define THIS_LORA_SENSOR_ADDRESS 5 // the address of the sensor
@@ -210,15 +211,28 @@ void loop() {
     static int msgNum = 0;
     bool needToSleep = false;
 
-    // XXX if fatal error then power down the ATmega328
+    // if fatal error then 
     if (mgFatalError) {
-        delay(1000);
-        return;
-    }   
+        if (PARTICLEPHOTON) {
+            delay(10); // loop forever
+            return;
+        } else { 
+            //power down the ATmega328
+        } 
+    }
+           
+
+/*
+    // XXXXX TESTING CODE FOR CONTINUOUS TRANSMISSIONS
+    if (!awaitingResponse) {
+        delay(3000);
+        mgButtonPressed = true;
+    }
+*/
+
+    // this is where the power down the ATmega code will go and we wait for an interrupt
 
     // test for button to be pressed and no transmission in progress
-    // this is where the power down code will go
-    //if(digitalRead(BUTTON_PIN) == LOW && !awaitingResponse) { // button press detected  
     if(mgButtonPressed && !awaitingResponse) { // button press detected 
         digitalWrite(GRN_LED_PIN, HIGH);
         debugPrintln(F("\n\r--------------------")); 
@@ -283,20 +297,24 @@ void loop() {
                 mglastSNR = LoRa.SNR;
 
                 // test for received data from the hub (denoted by "+RCV")
-                if(LoRa.receivedData.indexOf(F("+RCV")) >= 0) { // will be -1 of "+RCV" not in the string
+                int rcvIndex = LoRa.receivedData.indexOf(F("+RCV"));
+                if(rcvIndex >= 0) { // will be -1 of "+RCV" not in the string
                     
                     awaitingResponse = false; // we got a response
                     debugPrintln(F("response received"));
-
-                    if (LoRa.receivedData.indexOf(F("TESTOK")) >= 0) {
+                    int testokIndex = LoRa.receivedData.indexOf(F("TESTOK"));
+                    if (testokIndex >= 0) {
                         debugPrintln(F("response is TESTOK"));
                         blinkLED(GRN_LED_PIN, 3, 150);
-                    } else if (LoRa.receivedData.indexOf(F("NOPE")) >= 0) {
-                        debugPrintln(F("response is NOPE"));
-                        blinkLED(GRN_LED_PIN, 4, 250);
                     } else {
-                        debugPrintln(F("response is unrecognized"));
-                        blinkLED(RED_LED_PIN, 5, 250);
+                        int nopeIndex = LoRa.receivedData.indexOf(F("NOPE"));
+                        if (nopeIndex >= 0) {
+                            debugPrintln(F("response is NOPE"));
+                            blinkLED(GRN_LED_PIN, 4, 250);
+                        } else {
+                            debugPrintln(F("response is unrecognized"));
+                            blinkLED(RED_LED_PIN, 5, 250);
+                        }
                     }
                 } 
                 needToSleep = true;

--- a/Range_Testing/Range_Test_Sensor/RangeTestSensor/src/tpp_LoRa.cpp
+++ b/Range_Testing/Range_Test_Sensor/RangeTestSensor/src/tpp_LoRa.cpp
@@ -4,10 +4,13 @@
     as part of Team Practical Projects (tpp)
 
     20241212 - works on Particle Photon 2
+    v 2.1 pulled all string searches out of if() clause
 
 */
 
 #include "tpp_LoRa.h"
+
+#define VERSION 2.10
 
 #define TPP_LORA_DEBUG 0  // Do NOT enable this for ATmega328
 
@@ -286,7 +289,8 @@ int tpp_LoRa::sendCommand(const String& command) {
         tempString = F("received data = ");
         tempString += receivedData;
         debugPrintln(tempString);
-        if(receivedData.indexOf(F("+ERR")) >= 0) {
+        int errIndex = receivedData.indexOf(F("+ERR"));
+        if(errIndex >= 0) {
             debugPrintln(F("LoRa error"));
             retcode = 1;
         } else {
@@ -353,7 +357,8 @@ void tpp_LoRa::checkForReceivedMessage() {
         tempString += receivedData;
         debugPrintln(tempString);
 
-        if ((receivedData.indexOf(F("+OK")) == 0) && receivedData.length() == 3) {
+        int okIndex = receivedData.indexOf(F("+OK"));
+        if ((okIndex == 0) && receivedData.length() == 3) {
 
             // this is the normal OK from LoRa that the previous command succeeded
             debugPrintln(F("received data is +OK"));
@@ -361,7 +366,8 @@ void tpp_LoRa::checkForReceivedMessage() {
 
         } else {
 
-            if (receivedData.indexOf(F("+RCV")) < 0) {
+            int rcvIndex = receivedData.indexOf(F("+RCV"));
+            if (rcvIndex < 0) {
                 // We are expecting a +RCV message
                 debugPrintln(F("received data is not +RCV"));
                 receivedMessageState = -1;

--- a/arduinoSketchbook/RangeTestSensor/RangeTestSensor.ino
+++ b/arduinoSketchbook/RangeTestSensor/RangeTestSensor.ino
@@ -221,13 +221,13 @@ void loop() {
         } 
     }
            
-
+/*
     // XXXXX TESTING CODE FOR CONTINUOUS TRANSMISSIONS
     if (!awaitingResponse) {
         delay(200);
         mgButtonPressed = true;
     }
-
+*/
     // this is where the power down the ATmega code will go and we wait for an interrupt
 
     // test for button to be pressed and no transmission in progress

--- a/arduinoSketchbook/RangeTestSensor/RangeTestSensor.ino
+++ b/arduinoSketchbook/RangeTestSensor/RangeTestSensor.ino
@@ -41,7 +41,8 @@
  * 
  * version 2.0; 4/25/24
 
-    20241212 - version 2. works on Particle Photon 2 Verified on ATMega328
+    20241212 - version 2. works on Particle Photon 2 
+    v 2.1 pulled all string searches out of if() clauses
 
  */
 
@@ -58,7 +59,7 @@
     // SerialLogHandler logHandler(LOG_LEVEL_INFO);
 #endif
 
-#define VERSION 2.00
+#define VERSION 2.10
 #define STATION_NUM 0 // housekeeping; not used ini the code
 
 #define THIS_LORA_SENSOR_ADDRESS 5 // the address of the sensor
@@ -210,15 +211,26 @@ void loop() {
     static int msgNum = 0;
     bool needToSleep = false;
 
-    // XXX if fatal error then power down the ATmega328
+    // if fatal error then 
     if (mgFatalError) {
-        delay(1000);
-        return;
-    }   
+        if (PARTICLEPHOTON) {
+            delay(10); // loop forever
+            return;
+        } else { 
+            //power down the ATmega328
+        } 
+    }
+           
+
+    // XXXXX TESTING CODE FOR CONTINUOUS TRANSMISSIONS
+    if (!awaitingResponse) {
+        delay(200);
+        mgButtonPressed = true;
+    }
+
+    // this is where the power down the ATmega code will go and we wait for an interrupt
 
     // test for button to be pressed and no transmission in progress
-    // this is where the power down code will go
-    //if(digitalRead(BUTTON_PIN) == LOW && !awaitingResponse) { // button press detected  
     if(mgButtonPressed && !awaitingResponse) { // button press detected 
         digitalWrite(GRN_LED_PIN, HIGH);
         debugPrintln(F("\n\r--------------------")); 
@@ -283,20 +295,24 @@ void loop() {
                 mglastSNR = LoRa.SNR;
 
                 // test for received data from the hub (denoted by "+RCV")
-                if(LoRa.receivedData.indexOf(F("+RCV")) >= 0) { // will be -1 of "+RCV" not in the string
+                int rcvIndex = LoRa.receivedData.indexOf(F("+RCV"));
+                if(rcvIndex >= 0) { // will be -1 of "+RCV" not in the string
                     
                     awaitingResponse = false; // we got a response
                     debugPrintln(F("response received"));
-
-                    if (LoRa.receivedData.indexOf(F("TESTOK")) >= 0) {
+                    int testokIndex = LoRa.receivedData.indexOf(F("TESTOK"));
+                    if (testokIndex >= 0) {
                         debugPrintln(F("response is TESTOK"));
                         blinkLED(GRN_LED_PIN, 3, 150);
-                    } else if (LoRa.receivedData.indexOf(F("NOPE")) >= 0) {
-                        debugPrintln(F("response is NOPE"));
-                        blinkLED(GRN_LED_PIN, 4, 250);
                     } else {
-                        debugPrintln(F("response is unrecognized"));
-                        blinkLED(RED_LED_PIN, 5, 250);
+                        int nopeIndex = LoRa.receivedData.indexOf(F("NOPE"));
+                        if (nopeIndex >= 0) {
+                            debugPrintln(F("response is NOPE"));
+                            blinkLED(GRN_LED_PIN, 4, 250);
+                        } else {
+                            debugPrintln(F("response is unrecognized"));
+                            blinkLED(RED_LED_PIN, 5, 250);
+                        }
                     }
                 } 
                 needToSleep = true;
@@ -308,7 +324,7 @@ void loop() {
 
     // xxx this is where the power down code goes
     if (needToSleep) {
-        LoRa.sleep(); // put the LoRa module to sleep
+        //LoRa.sleep(); // put the LoRa module to sleep
     }
 
 } // end of loop()

--- a/arduinoSketchbook/RangeTestSensor/tpp_LoRa.cpp
+++ b/arduinoSketchbook/RangeTestSensor/tpp_LoRa.cpp
@@ -3,7 +3,7 @@
     created by Bob Glicksman and Jim Schrempp 2024
     as part of Team Practical Projects (tpp)
 
-    20241212 - works on Particle Photon 2  Verified on ATMega328
+    20241212 - works on Particle Photon 2
 
 */
 

--- a/arduinoSketchbook/RangeTestSensor/tpp_LoRa.h
+++ b/arduinoSketchbook/RangeTestSensor/tpp_LoRa.h
@@ -3,7 +3,7 @@
     created by Bob Glicksman and Jim Schrempp 2024
     as part of Team Practical Projects (tpp)
 
-    20241212 - version 2. works on Particle Photon 2  Verified on ATMega328
+    20241212 - version 2. works on Particle Photon 2
 
 */
 /*

--- a/arduinoSketchbook/RangeTestSensor/tpp_LoRaGlobals.h
+++ b/arduinoSketchbook/RangeTestSensor/tpp_LoRaGlobals.h
@@ -3,7 +3,7 @@
 
     Include this in all modules of the LoRa sensor and hub
 
-    20241212 - works on Particle Photon 2. Verified on ATMega328
+    20241212 - works on Particle Photon 2
     
     (c) 2024 Bob Glicksmand and Jim Schrempp
 


### PR DESCRIPTION
Pulled all of the substring search code out of the if() clauses. This allowed the ATmega to run over 300 transactions in a row.

LoRa power down is disabled in this code - see the bottom of the main loop.

Better comments about where the ATmega power down code should go (where I think it should go).

Note that hub has not been updated to this new library. Running on a P2 the current hub code will hang after about 150 transactions. 