### PR TITLE
cleaned up P2 debug printing

### DIFF
--- a/Range_Testing/Range_Test_Hub/LoRaRangeTestHub/src/LoRaRangeTestHub.ino
+++ b/Range_Testing/Range_Test_Hub/LoRaRangeTestHub/src/LoRaRangeTestHub.ino
@@ -58,9 +58,9 @@ void logToParticle(String message, int deviceNum, String payload, int SNRhub1, i
         + "|deviceNum=" + String(deviceNum) + "|payload=" + payload 
         + "|SNRhub1=" + String(SNRhub1) + "|RSSIHub1=" + String(RSSIHub1);
 
-    Serial.println("cloudLogging:" + data);
+    DEBUG_SERIAL.println("cloudLogging:" + data);
     long rtn = Particle.publish("LoRaHubLogging", data, PRIVATE);
-    Serial.println("cloudLogging return: " + String(rtn));
+    DEBUG_SERIAL.println("cloudLogging return: " + String(rtn));
 }
 
 void setup() {
@@ -69,11 +69,11 @@ void setup() {
     pinMode(LORA_ADDRESS_PIN, INPUT_PULLUP); // used to set LoRa address on boot
 
     digitalWrite(D7, HIGH);
-    Serial.begin(9600); // the USB serial port 
-    Serial1.begin(38400); // (115200);  // the LoRa device
+    DEBUG_SERIAL.begin(9600); // the USB serial port 
+    waitFor(DEBUG_SERIAL.isConnected, 15000);
 
     waitUntil(Particle.connected);  // wait for the cloud to connect
-    Serial.println("Hub version: " + String(VERSION));
+    DEBUG_SERIAL.println("Hub version: " + String(VERSION));
 
     int addressForLoRa = TPP_LORA_HUB_ADDRESS;
     int setAddressForHub = digitalRead(LORA_ADDRESS_PIN);
@@ -82,26 +82,26 @@ void setup() {
     } 
 
     if (LoRa.begin() != 0) {
-        Serial.println("Error initializing LoRa device");
+        DEBUG_SERIAL.println("Error initializing LoRa device");
         while(1) {blinkTimes(50);};
         return;
     }
 
     if (LoRa.configDevice(addressForLoRa) != 0) {  // initialize the LoRa device 
-        Serial.println("Error configuring LoRa device");
+        DEBUG_SERIAL.println("Error configuring LoRa device");
         while(1) {blinkTimes(50);};
         return;
     }
     
     if (LoRa.readSettings() != 0) {
-        Serial.println("Error reading LoRa settings");
+        DEBUG_SERIAL.println("Error reading LoRa settings");
         blinkTimes(50);
         while(1) {blinkTimes(50);};
         return;
     }
 
-    Serial.println("Hub ready for testing ...");
-    Serial.print("waiting for data ...\n");
+    DEBUG_SERIAL.println("Hub ready for testing ...");
+    DEBUG_SERIAL.print("waiting for data ...\n");
 
     digitalWrite(DEBUG_LED_PIN, LOW);
 
@@ -117,8 +117,8 @@ void loop() {
     LoRa.checkForReceivedMessage();
     switch (LoRa.receivedMessageState) {
         case -1: // error
-            Serial.println("Error reading data from LoRa module");
-            Serial.println("Waiting for messages");
+            DEBUG_SERIAL.println("Error reading data from LoRa module");
+            DEBUG_SERIAL.println("Waiting for messages");
             break;
         case 0: // no message
             break;
@@ -130,7 +130,7 @@ void loop() {
 
             String debugMessage = "From device: " + String(deviceNum);
             debugMessage += " payload: " + LoRa.payload;
-            Serial.println(debugMessage);
+            DEBUG_SERIAL.println(debugMessage);
 
             int helloIndex = LoRa.payload.indexOf(TPP_LORA_MSG_GATE_SENSOR);
             if(helloIndex >= 0) { // will be -1 if "HELLO" not in the string
@@ -141,13 +141,13 @@ void loop() {
                     logMessage = "TESTOK";
                     messageSent = "TESTOK";
                 } else {
-                    Serial.println("error sending TESTOK to sensor");
+                    DEBUG_SERIAL.println("error sending TESTOK to sensor");
                     logMessage = "Send of TESTOK failed";
                 };
 
             } else {
 
-                Serial.println("received data does not start with a known character (see tpp_LoRa.h)");
+                DEBUG_SERIAL.println("received data does not start with a known character (see tpp_LoRa.h)");
                 LoRa.transmitMessage(deviceNum, "NOPE");
                 logMessage = "NOPE";
                 messageSent = "NOPE";
@@ -155,7 +155,7 @@ void loop() {
             } // end of if(receivedData.indexOf("HELLO") > 0)
 
 
-            Serial.println("sent message: " + messageSent);
+            DEBUG_SERIAL.println("sent message: " + messageSent);
 
             if (LOG_TO_CLOUD){
                 // log the data to the cloud
@@ -163,7 +163,7 @@ void loop() {
             }
 
             digitalWrite(DEBUG_LED_PIN, LOW);
-            Serial.println("Waiting for messages");
+            DEBUG_SERIAL.println("Waiting for messages");
 
             break;
     } // end of switch

--- a/Range_Testing/Range_Test_Hub/LoRaRangeTestHub/src/tpp_LoRa.cpp
+++ b/Range_Testing/Range_Test_Hub/LoRaRangeTestHub/src/tpp_LoRa.cpp
@@ -19,24 +19,26 @@
 
 bool mg_LoRaBusy = false;
 
-String tempString; 
 
+// define the parameter as const String& to avoid copying the string
+// which important on the ATmega328
 void tpp_LoRa::debugPrintln(const String& message) {
     #if TPP_LORA_DEBUG
-        tempString = F("tpp_LoRa: ");
-        tempString += message;
-        DEBUG_SERIAL.println(tempString);
+        String msg = "tpp_LoRa: "; // if we don't declare a string here the println fails
+        msg += message;
+        DEBUG_SERIAL.println(msg);
     #endif
 }
 void tpp_LoRa::debugPrintNoHeader(const String& message){
     #if TPP_LORA_DEBUG
-        DEBUG_SERIAL.print(message);
+        String msg  = message;
+        DEBUG_SERIAL.println(msg);
     #endif
 }
 void tpp_LoRa::debugPrint(const String& message){
     #if TPP_LORA_DEBUG
-        tempString += message;
-        DEBUG_SERIAL.println(tempString);
+        String msg  = message;
+        DEBUG_SERIAL.print(msg);
     #endif
 }
 
@@ -67,6 +69,8 @@ int tpp_LoRa::begin() {
     receivedData.reserve(100);
     payload.reserve(75);
     tempString.reserve(50);
+
+    debugPrintln(F("Start LoRa initialization")); // so this AFTER tempString is reserved
 
     LORA_SERIAL.begin(38400);
     LORA_SERIAL.setTimeout(10);
@@ -322,7 +326,7 @@ int tpp_LoRa::sendCommand(const String& command) {
         debugPrintln(tempString);
         int errIndex = receivedData.indexOf(F("+ERR"));
         if(errIndex >= 0) {
-            debugPrintln(F("LoRa error"));
+            debugPrintln(F("LoRa returned +ERR"));
             retcode = 1;
         } else { 
             //int rcvIndex = receivedData.indexOf(F("+OK"));

--- a/Range_Testing/Range_Test_Hub/LoRaRangeTestHub/src/tpp_LoRa.h
+++ b/Range_Testing/Range_Test_Hub/LoRaRangeTestHub/src/tpp_LoRa.h
@@ -46,6 +46,7 @@ private:
     void blinkLED(int ledpin, int number, int delayTimeMS) ;
 
     String LoRaStringBuffer;
+    String tempString; 
     int isLoRaAwake = true; // true = awake, false = asleep
 
     // function to send AT commands to the LoRa module

--- a/Range_Testing/Range_Test_Hub/LoRaRangeTestHub/src/tpp_LoRaGlobals.h
+++ b/Range_Testing/Range_Test_Hub/LoRaRangeTestHub/src/tpp_LoRaGlobals.h
@@ -22,7 +22,7 @@
     // CONSTANTS 
     const int BUTTON_PIN = D0;   // the pushbutton is on digital pin 2 which is ATMega328 chip pin 4
     const int GRN_LED_PIN = D2;  // the Green LED is on digital pin 7 which is the P2 onboard LED
-    const int RED_LED_PIN = D19;  // the Red LED is on digital pin 8 
+    //const int RED_LED_PIN = D19;  // the Red LED is on digital pin 8 
     // xxx additional pins for device address customization
     const int ADR1_PIN = D3;  // the device address = BASE_DEVICE_ADDRESS + (ADR4 + ADR2 + ADR1)
     const int ADR2_PIN = D4;  // the device address = BASE_DEVICE_ADDRESS + (ADR4 + ADR2 + ADR1)


### PR DESCRIPTION
When I turned on LoRa debug the serial output was gacked. I must not have tested debug printing on the hub. I found that the .ino file also declared Serial port for debugging, causing bad things to happen. I have corrected that and now it works. There is no substantial change to the actual functionality.